### PR TITLE
Deployment Test

### DIFF
--- a/contracts/MultisigLiquidator.sol
+++ b/contracts/MultisigLiquidator.sol
@@ -111,6 +111,10 @@ contract MultisigLiquidator {
         return liquidatorCall(abi.encodeWithSignature("reclaimStake(address,uint256)", _destination, _stake), signatures);
     }
 
+    function setPool(address _pool, bytes[2] memory signatures) public returns (bytes memory) {
+        return liquidatorCall(abi.encodeWithSignature("setPool(address)", _pool), signatures);
+    }
+
     function claimOwnership(bytes[2] memory signatures) public returns (bytes memory) {
         return liquidatorCall(abi.encodeWithSignature("claimOwnership()"), signatures);
     }

--- a/contracts/mocks/LiquidatorMock.sol
+++ b/contracts/mocks/LiquidatorMock.sol
@@ -6,28 +6,23 @@ pragma experimental ABIEncoderV2;
 import "../Liquidator.sol";
 
 contract LiquidatorMock is Liquidator {
-    //UniswapFactory mockUniswapFactory;
     address mockPool;
     Registry mockRegistry;
     IERC20 mockOutputToken;
     IERC20 mockStakeToken;
     UniswapV1 mockOutputUniswap;
     UniswapV1 mockStakeUniswap;
-    constructor(address _pool, Registry _registry, /*UniswapFactory _uniswapFactory,*/ IERC20 _outputToken, IERC20 _stakeToken, UniswapV1 _outputUniswap, UniswapV1 _stakeUniswap) public {
-        mockPool = _pool;
+    constructor(Registry _registry, IERC20 _outputToken, IERC20 _stakeToken, UniswapV1 _outputUniswap, UniswapV1 _stakeUniswap) public {
         mockRegistry = _registry;
-        //mockUniswapFactory = _uniswapFactory;
         mockOutputToken = _outputToken;
         mockStakeToken = _stakeToken;
         mockOutputUniswap = _outputUniswap;
         mockStakeUniswap = _stakeUniswap;
         initialize();
     }
-    /*
-    function uniswapFactory() internal view returns (UniswapFactory uniswapFactory_) {
-        uniswapFactory_ = mockUniswapFactory;
+    function setPool(address _pool) external onlyOwner {
+        mockPool = _pool;
     }
-    */
     function pool() internal view returns (address pool_) {
         pool_ = mockPool;
     }

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ganache-cli -l 0x7a1200 --allowUnlimitedContractSize -k istanbul >/dev/null &
+ganache-cli -a 15 -l 0x7a1200 --allowUnlimitedContractSize -k istanbul >/dev/null &
 GPID=$!
 sleep 1
 truffle test $@

--- a/test/Liquidator.test.js
+++ b/test/Liquidator.test.js
@@ -50,7 +50,8 @@ contract('Liquidator', function(accounts) {
         await this.rewardToken.mint(oneHundred, ONE_HUNDRED, {from:issuer});
         await this.stakeToken.mint(oneHundred, ONE_HUNDRED, {from:issuer});
         this.airswap = await Airswap.new(this.transferHandlerRegistry.address, {from: owner})
-        this.liquidator = await Liquidator.new(fakePool, this.registry.address, this.rewardToken.address, this.stakeToken.address, this.outputUniswap.address, this.stakeUniswap.address, {from: owner})
+        this.liquidator = await Liquidator.new(this.registry.address, this.rewardToken.address, this.stakeToken.address, this.outputUniswap.address, this.stakeUniswap.address, {from: owner})
+        await this.liquidator.setPool(fakePool, {from:owner})
         await this.registry.subscribe(AIRSWAP_VALIDATOR, this.liquidator.address, {from: owner})
         await this.registry.subscribe(APPROVED_BENEFICIARY, this.liquidator.address, {from: owner})
         await this.registry.setAttributeValue(this.airswap.address, AIRSWAP_VALIDATOR, hashDomain(this.airswap.address), {from: owner})


### PR DESCRIPTION

#### Changes
Integration.test.js tests deployment.
Because the pool cannot know the liquidator address beforehand without create2 and create2 is not natively supported, we create a setPool method in the Liquidator.
Reviewers @terryli0095